### PR TITLE
remove hidden-md class from demo element

### DIFF
--- a/src/app/template/device-visibility.html
+++ b/src/app/template/device-visibility.html
@@ -3,6 +3,6 @@
 	<h3>Demo Control</h3>
 	<p>Hide and show the following box based on the device size. You'll need to
 		change you browser size in order to preview the effect.</p>
-	<div class="demo-element hidden-md">
+	<div class="demo-element">
 	</div>
 </div>


### PR DESCRIPTION
the hidden-md class never gets removed/added in the demo, and gets hidden at different breakpoints that what the controls are doing.  It appears like the control doesn't work in the demo.  Remove the class and it behaves correctly with all the settings toggled and screen resized to the various breakpoints.